### PR TITLE
Return $item from addItem 

### DIFF
--- a/code/order/Order.php
+++ b/code/order/Order.php
@@ -576,6 +576,8 @@ class Order extends DataObject implements PermissionProvider {
     }
     
     $this->updateTotal();
+    
+    return $item;
 	}
 	
 	/**


### PR DESCRIPTION
When adding items to an order through code, it's handy to have a reference to the item just added (for cases where there needs to be additional tracking of the item outside the order).
