### PR TITLE
Add the ability to override the title of the 'Quantity' field on the product form

### DIFF
--- a/code/form/ProductForm.php
+++ b/code/form/ProductForm.php
@@ -202,8 +202,8 @@ class ProductForm extends Form {
 	 * Usage:
 	 * 
 	 * class WineProductForm extends DataExtension {	 
-	 * 	public function getQuantityFieldTitle(array &$titles) {    
-	 *		$titles[] = "No of cases";
+	 * 	public function getQuantityFieldTitle(&$title) {    
+	 *		return $title = "No of cases";
 	 * 	}
 	 * }
 	 * 
@@ -212,9 +212,9 @@ class ProductForm extends Form {
 	 * @return string The title of the quantity field
 	 */
 	public function getQuantityFieldTitle() {
-		$results = array();
-		$this->extend("getQuantityFieldTitle", $results);		
-		return (empty($results) ? "Quantity" : $results[0]);
+		$title = "Quantity";
+		$this->extend("getQuantityFieldTitle", $title);		
+		return $title;
 	}
 
 

--- a/code/form/ProductForm.php
+++ b/code/form/ProductForm.php
@@ -90,7 +90,7 @@ class ProductForm extends Form {
 			$prev = $attribute;
 		}
 
-		$fields->push(ProductForm_QuantityField::create('Quantity', 'Quantity', $this->quantity));
+		$fields->push(ProductForm_QuantityField::create('Quantity', $this->getQuantityFieldTitle(), $this->quantity));
 
 		$this->extend('updateFields', $fields);
 		$fields->setForm($this);
@@ -195,6 +195,28 @@ class ProductForm extends Form {
 		}
 		$this->goToNextPage();
 	}
+
+	/**
+	 * Gets the name of the quantity field. Intended to be overridden if necessary in a Data Extension.	
+	 * 
+	 * Usage:
+	 * 
+	 * class WineProductForm extends DataExtension {	 
+	 * 	public function getQuantityFieldTitle(array &$titles) {    
+	 *		$titles[] = "No of cases";
+	 * 	}
+	 * }
+	 * 
+	 * ProductForm::add_extension('WineProductForm');
+	 * 
+	 * @return string The title of the quantity field
+	 */
+	public function getQuantityFieldTitle() {
+		$results = array();
+		$this->extend("getQuantityFieldTitle", $results);		
+		return (empty($results) ? "Quantity" : $results[0]);
+	}
+
 
 	/**
 	 * Find a product based on current request - maybe shoul dbe deprecated?


### PR DESCRIPTION
I had the need to have a custom title for the 'Quantity' field. It was hardcoded to 'Quantity' (which probably works in 99% of cases) but I needed to make it say something else.

Im not sure if this is the best approach since its very specific to the Quantity field and doesn't allow overriding and of the other field names. Could this approach be followed for other field names (eg, define a method for getting the title of each field name) or is there a better way?
