### PR TITLE
Hide unselectable/disabled options for product variations

### DIFF
--- a/javascript/Attribute_OptionField.js
+++ b/javascript/Attribute_OptionField.js
@@ -24,11 +24,25 @@
 			_updateOptions: function(e) {
 				var self = this;
 				var options = this.data('map')[$(e.currentTarget).val()];
+				var superOption = $('.attribute_option select:eq(0)').val();
+
+				var form = this.closest('form');
+				var variations = form.data('map');
 
 				$('option', this).remove();
 				if (options != null) {
 					$.each(options, function(val, text) {
-						$("<option/>").attr("value", val).html(text).appendTo(self);
+						var add = false;
+						for (var i = 0; i < variations.length; i++){
+							var variationOptions = variations[i]['options'];
+							if($.inArray(superOption, variationOptions) > -1 && $.inArray(val, variationOptions) > -1) {
+								var add = true;
+							}
+						}
+
+						if(add) {
+							$("<option/>").attr("value", val).html(text).appendTo(self);
+						}
 					});
 				}
 				this.change();


### PR DESCRIPTION
See issue: https://github.com/frankmullenger/silverstripe-swipestripe/issues/23

This works for me; use the 'super value' to only select truly available options. Might need some optimizations, using a double inArray() call....
