### PR TITLE
Product variation dropdown fixes

### DIFF
--- a/code/form/ProductForm.php
+++ b/code/form/ProductForm.php
@@ -40,18 +40,20 @@ class ProductForm extends Form {
 
 		if ($variations && $variations->exists()) foreach ($variations as $variation) {
 
-			$variationPrice = $variation->Price();
-			
-			$amount = new Price();
-			$amount->setAmount($productPrice->getAmount() + $variationPrice->getAmount());
-			$amount->setCurrency($productPrice->getCurrency());
-			$amount->setSymbol($productPrice->getSymbol());
+			if ($variation->isEnabled()) {
+				$variationPrice = $variation->Price();
+				
+				$amount = new Price();
+				$amount->setAmount($productPrice->getAmount() + $variationPrice->getAmount());
+				$amount->setCurrency($productPrice->getCurrency());
+				$amount->setSymbol($productPrice->getSymbol());
 
-			$map[] = array(
-				'price' => $amount->Nice(),
-				'options' => $variation->Options()->column('ID'),
-				'free' => _t('Product.FREE', 'Free'),
-			);
+				$map[] = array(
+					'price' => $amount->Nice(),
+					'options' => $variation->Options()->column('ID'),
+					'free' => _t('Product.FREE', 'Free'),
+				);
+			}
 		}
 
 		$this->setAttribute('data-map', json_encode($map));

--- a/javascript/Attribute_OptionField.js
+++ b/javascript/Attribute_OptionField.js
@@ -47,7 +47,11 @@
 									if (variationOptions.filter(function(elem) {
 										return partial.indexOf(elem) > -1;
 									}).length == partial.length) {
-										$("<option/>").attr("value", val).html(text).appendTo(self);
+									
+										//check if the option getting added does not already exist in the dropdown (to avoid duplicate options)
+										if ($('option[value='+val+']',self).length == 0) {
+											$("<option/>").attr("value", val).html(text).appendTo(self);
+										}
 									}
 								}
 							}


### PR DESCRIPTION
ProductForm.php:
Add a check to the constructor to check that the variations passed to javascipt have a status of enabled in the admin.

This prevents disabled variations from appearing on the frontend via json, which then get added to the nth dropdown (where n>=2).
(The first drop down doesn't get modified)
Eg:
Variations:
ID  Size    Style   Colour  Status
1   L   T-shirt Green   Enabled
2   M   T-shirt Green   Enabled
3   M   T-shirt Black   Enabled
4   M   T-shirt Pink    Disabled
The last variation shouldn't be added to the json / shown in the dropdowns:
The php that builds the first select (Size) includes L and M.
The php that builds the json data-map then includes the last variation (M:T-shirt:Pink:Disabled) because the size M is selectable for other variations despite this variation being disabled.

Attribute_OptionField.js
Add a check to prevent multiple instances of the same option being added to a given dropdown by javascript.

Description of problem:
With the above dataset, and with M selected for size, T-shirt gets added to the Style dropdown 2 or 3 times. 2 times if the previous fix is added, and 3 times if not.
The number of times the option is repeated is equal to the number of variations that include it after the set is filtered by the first dropdown.
So in this example, when M is selected for Size, there are:
2 'T-shirt' options added to the Style select (one for each of variations 2-3) when the ProductForm.php fix above is applied, and
3 'T-shirt' options added to the Style select (one for each of variations 2-4) when the ProductForm.php fix above is not applied.
