### PR TITLE
Modifications for Bitcoin and other digital currency

### DIFF
--- a/code/admin/PriceField.php
+++ b/code/admin/PriceField.php
@@ -32,8 +32,27 @@ class PriceField extends CurrencyField {
 	 */
 	public function setValue($val) {
 		if(!$val) $val = 0.00;
-		$this->value = number_format((double)preg_replace('/[^0-9.\-]/', '', $val), 2);
+		$shopConfig = ShopConfig::current_shop_config();
+		$precision = 2;		//precision should always be two decimals, and only more if specified in ShopConfig
+		if($shopConfig && $shopConfig->BaseCurrencyPrecision > 2) {
+			$precision = $shopConfig->BaseCurrencyPrecision;
+		}
+
+		$this->value = number_format((double)preg_replace('/[^0-9.\-]/', '', $val), $precision);
 		return $this;
+	}
+
+
+	public function validate($validator) {
+		if(!empty ($this->value)
+				//validate against any number of digits after the decimal place
+				&& !preg_match('/^\s*(\-?\$?|\$\-?)?(\d{1,3}(\,\d{3})*|(\d+))(\.\d+)?\s*$/', $this->value)) {
+
+			$validator->validationError($this->name, _t('Form.VALIDCURRENCY', "Please enter a valid currency"),
+				"validation", false);
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/code/admin/ShopAdmin.php
+++ b/code/admin/ShopAdmin.php
@@ -494,7 +494,9 @@ class ShopAdmin_BaseCurrency extends ShopAdmin {
 					TextField::create('BaseCurrency', _t('ShopConfig.BASE_CURRENCY', 'Base Currency'))
 						->setRightTitle('3 letter code for base currency - <a href="http://en.wikipedia.org/wiki/ISO_4217#Active_codes" target="_blank">available codes</a>'),
 					TextField::create('BaseCurrencySymbol', _t('ShopConfig.BASE_CURRENCY_SYMBOL', 'Base Currency Symbol'))
-						->setRightTitle('Symbol to be used for the base currency e.g: $')
+						->setRightTitle('Symbol to be used for the base currency e.g: $'),
+					NumericField::create('BaseCurrencyPrecision', _t('ShopConfig.BASE_CURRENCY_PRECISION', 'Base Currency Precision'))
+						->setRightTitle('Most currencies use two digits after the decimal place. If using digital currencies like Bitcoin, precision should be at least eight digits after the decimal.')
 				)
 			)
 		);

--- a/code/admin/ShopConfig.php
+++ b/code/admin/ShopConfig.php
@@ -16,6 +16,7 @@ class ShopConfig extends DataObject {
 		'LicenceKey' => 'Varchar',
 
 		'BaseCurrency' => 'Varchar(3)',
+		'BaseCurrencyPrecision' => 'Int',	//number of digits after the decimal place
 		'BaseCurrencySymbol' => 'Varchar(10)',
 
 		'CartTimeout' => 'Int',
@@ -37,6 +38,7 @@ class ShopConfig extends DataObject {
 	);
 
 	private static $defaults = array(
+		'BaseCurrencyPrecision' => 2,
 		'CartTimeout' => 1,
 		'CartTimeoutUnit' => 'hour',
 		'StockCheck' => false,

--- a/code/order/Item.php
+++ b/code/order/Item.php
@@ -12,7 +12,7 @@ class Item extends DataObject {
 	 * @var Array
 	 */
 	private static $db = array(
-		'Price' => 'Decimal(19,4)',
+		'Price' => 'Decimal(19,8)',
 		'Quantity' => 'Int',
 		'ProductVersion' => 'Int',
 		'VariationVersion' => 'Int'

--- a/code/order/ItemOption.php
+++ b/code/order/ItemOption.php
@@ -25,7 +25,7 @@ class ItemOption extends DataObject {
 	 */
 	private static $db = array(
 		'Description' => 'Varchar',
-		'Price' => 'Decimal(19,4)'
+		'Price' => 'Decimal(19,8)'
 	);
 
 	public function Amount() {

--- a/code/order/Modification.php
+++ b/code/order/Modification.php
@@ -22,7 +22,7 @@ class Modification extends DataObject {
 	 */
 	private static $db = array(
 		'Value' => 'Int',
-		'Price' => 'Decimal(19,4)',
+		'Price' => 'Decimal(19,8)',
 		'Description' => 'Text',
 		'SubTotalModifier' => 'Boolean',
 		'SortOrder' => 'Int'

--- a/code/order/Order.php
+++ b/code/order/Order.php
@@ -36,8 +36,8 @@ class Order extends DataObject implements PermissionProvider {
 		'Status' => "Enum('Pending,Processing,Dispatched,Cancelled,Cart','Cart')",
 		'PaymentStatus' => "Enum('Unpaid,Paid','Unpaid')",
 
-		'TotalPrice' => 'Decimal(19,4)',
-		'SubTotalPrice' => 'Decimal(19,4)',
+		'TotalPrice' => 'Decimal(19,8)',
+		'SubTotalPrice' => 'Decimal(19,8)',
 
 		'BaseCurrency' => 'Varchar(3)',
 		'BaseCurrencySymbol' => 'Varchar(10)',

--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -21,7 +21,7 @@ class Product extends Page {
 	 * @var Array
 	 */
 	private static $db = array(
-		'Price' => 'Decimal(19,4)',
+		'Price' => 'Decimal(19,8)',
 		'Currency' => 'Varchar(3)'
 	);
 

--- a/code/product/Variation.php
+++ b/code/product/Variation.php
@@ -161,6 +161,8 @@ class Variation extends DataObject {
 			$this->dbObject('Status')->enumValues()
 		)->setRightTitle('You can disable a variation to prevent it being sold'));
 
+		$this->extend('updateCMSFields', $fields);
+
 		return $fields;
 	}
 	

--- a/code/product/Variation.php
+++ b/code/product/Variation.php
@@ -18,7 +18,7 @@ class Variation extends DataObject {
 	 * @var Array
 	 */
 	private static $db = array(
-		'Price' => 'Decimal(19,4)',
+		'Price' => 'Decimal(19,8)',
 		'Currency' => 'Varchar(3)',
 		'Status' => "Enum('Enabled,Disabled','Enabled')",
 		'SortOrder' => 'Int'
@@ -160,8 +160,6 @@ class Variation extends DataObject {
 			'Status', 
 			$this->dbObject('Status')->enumValues()
 		)->setRightTitle('You can disable a variation to prevent it being sold'));
-
-		$this->extend('updateCMSFields', $fields);
 
 		return $fields;
 	}


### PR DESCRIPTION
I have been working on a seperate project using Swipestripe that accepts Bitcoins as a payment option. Swipestripe does not provide adequate support for digital currencies out of the box, so I have made a few modifications.
- I have adjusted the PriceField in the CMS to allow a greater precision than two digits, as this means the smallest unit of price we can allow at current market rates is approximately NZD $7. Behind the scenes, Swipestripe can handle four (so $0.07) but Bitcoin supports up to eight.
- I have updated all Decimal(19,4) database fields to Decimal(19,8).
- I created a BaseCurrencyPrecision field in ShopConfig with a default value of 2. PriceField uses the greater value if set, and validates more than 2 digits after the decimal place.
