### PR TITLE
UPDATE If set, BaseCurrencyPrecision should be used in Order processing

### DIFF
--- a/code/form/OrderForm.php
+++ b/code/form/OrderForm.php
@@ -315,9 +315,14 @@ class OrderForm extends Form {
 		$order->onBeforePayment();
 
 		try {
+			$shopConfig = ShopConfig::current_shop_config();
+			$precision = 2;		//precision should always be two decimals, and only more if specified in ShopConfig
+			if($shopConfig && $shopConfig->BaseCurrencyPrecision > 2) {
+				$precision = $shopConfig->BaseCurrencyPrecision;
+			}
 
 			$paymentData = array(
-				'Amount' => number_format($order->Total()->getAmount(), 2, '.', ''),
+				'Amount' => number_format($order->Total()->getAmount(), $precision, '.', ''),
 				'Currency' => $order->Total()->getCurrency(),
 				'Reference' => $order->ID
 			);


### PR DESCRIPTION
Prior to this commit number_format in Order::process is hardcoded with a precision of 2. As previously, the default precision will be two, and only changed if BaseCurrencyPrecision is set in the ShopConfig.

NOTE: A current limitation of the Silverstripe framework is that the Money DBfield uses Decimal(19,4) for the Amount, which is outside the scope of Swipestripe and the Payment modules. I'm creating a pull request to address this;
