### PR TITLE
Fixes #81 Access level

### DIFF
--- a/code/product/Variation.php
+++ b/code/product/Variation.php
@@ -392,7 +392,7 @@ class Variation extends DataObject implements PermissionProvider {
 	 * @see DataObject::validate()
 	 * @return ValidationResult
 	 */
-	protected function validate() {
+	public function validate() {
 		
 		$result = new ValidationResult(); 
 


### PR DESCRIPTION
Fixes #81 Access level to Variation::validate() must be public (as in class DataObject)
