### PR TITLE
Replacing deprecated $BaseHref in template

### DIFF
--- a/templates/Layout/AccountPage_order.ss
+++ b/templates/Layout/AccountPage_order.ss
@@ -27,7 +27,7 @@
 					<strong class="alert-heading"><% _t('AccountPage_order.WARNING','Warning!') %></strong>
 					There is an outstanding amount on this order, please <a href="{$AbsoluteBaseURL}/account/repay/{$ID}">complete payment for this order here</a>.
 				</p>
-			<% end_if %>		  
+			<% end_if %>
 			
 			<% if CustomerUpdates %>
 				<% include OrderNotes %>

--- a/templates/Layout/AccountPage_order.ss
+++ b/templates/Layout/AccountPage_order.ss
@@ -25,7 +25,7 @@
 			<% if TotalOutstanding.Amount != 0 %>
 				<p class="alert alert-error">
 					<strong class="alert-heading"><% _t('AccountPage_order.WARNING','Warning!') %></strong>
-					There is an outstanding amount on this order, please <a href="{$BaseHref}/account/repay/{$ID}">complete payment for this order here</a>.
+					There is an outstanding amount on this order, please <a href="{$AbsoluteBaseURL}/account/repay/{$ID}">complete payment for this order here</a>.
 				</p>
 			<% end_if %>		  
 			


### PR DESCRIPTION
$BaseHref has been deprecated. I have replaced this in the template with $AbsoluteBaseURL.
