### PR TITLE
Use `getIDList` to enumerate IDs instead of `map()->toArray()`.

### DIFF
--- a/code/product/Variation.php
+++ b/code/product/Variation.php
@@ -321,9 +321,9 @@ class Variation extends DataObject implements PermissionProvider {
 
 		//Hacky way to get new option IDs from $this->record because $this->Options() returns existing options
 		//not the new ones passed in POST data    
-		$attributeIDs = $this->Product()->Attributes()->map()->toArray();
+		$attributeIDs = $this->Product()->Attributes()->getIDList();
 		$variationAttributeOptions = array();
-		if ($attributeIDs) foreach ($attributeIDs as $attributeID => $title) {
+		if ($attributeIDs) foreach ($attributeIDs as $attributeID) {
 			
 			$attributeOptionID = (isset($this->record['Options[' . $attributeID .']'])) ? $this->record['Options[' . $attributeID .']'] : null;
 			if ($attributeOptionID) {


### PR DESCRIPTION
I have a use-case where I want to be able to duplicate a product including attributes/options and variations. I do so by creating a `DataExtension` for `Product`.

There's an issue with using `map()->toArray()` in `Variation->isDuplicate` though, since it fails with UnsavedRelationLists (when duplicating a product page, `Product->Attributes` will be of type `UnsavedRelationList` during the time the page is being duplicated).

That's the lengthy explanation why I'm proposing to use `getIDList` over `map()->toArray()`. It's not only more concise, but also more stable, since it also works with `UnsavedRelationList`.
