### PR TITLE
Ensure that quantity is always numeric.

### DIFF
--- a/code/form/ProductForm.php
+++ b/code/form/ProductForm.php
@@ -92,7 +92,8 @@ class ProductForm extends Form {
 			$prev = $attribute;
 		}
 
-		$fields->push(ProductForm_QuantityField::create('Quantity', _t('ProductForm.QUANTITY', 'Quantity'), $this->quantity));
+		$fields->push(ProductForm_QuantityField::create(
+			'Quantity', _t('ProductForm.QUANTITY', 'Quantity'), is_numeric($this->quantity) ? $this->quantity : 1));
 
 		$this->extend('updateFields', $fields);
 		$fields->setForm($this);
@@ -244,7 +245,7 @@ class ProductForm extends Form {
 	 */
 	private function getQuantity() {
 		$quantity = $this->getRequest()->requestVar('Quantity');
-		return (isset($quantity)) ? $quantity : 1;
+		return (isset($quantity) && is_numeric($quantity)) ? $quantity : 1;
 	}
 
 	private function getOptions() {


### PR DESCRIPTION
I stumbled accross a weird issue, where quantity was of type `SS_HTTPRequest`, resulting in the following error message showing up in the logs:

```
[Warning] trim() expects parameter 1 to be string, object given
```

This PR ensures that quantity is always numeric.
