### PR TITLE
Add extendedCan checks to all canXXX methods

### DIFF
--- a/code/customer/AccountPage.php
+++ b/code/customer/AccountPage.php
@@ -38,6 +38,10 @@ class AccountPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	
@@ -48,6 +52,10 @@ class AccountPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 
@@ -65,6 +73,10 @@ class AccountPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDeleteFromLive($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	

--- a/code/customer/CartPage.php
+++ b/code/customer/CartPage.php
@@ -38,6 +38,10 @@ class CartPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	
@@ -48,6 +52,10 @@ class CartPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 
@@ -65,6 +73,10 @@ class CartPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDeleteFromLive($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	

--- a/code/customer/CheckoutPage.php
+++ b/code/customer/CheckoutPage.php
@@ -38,6 +38,10 @@ class CheckoutPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	
@@ -48,6 +52,10 @@ class CheckoutPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 
@@ -65,6 +73,10 @@ class CheckoutPage extends Page {
 	 * @return Boolean Always returns false
 	 */
 	function canDeleteFromLive($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return false;
 	}
 	

--- a/code/customer/Customer.php
+++ b/code/customer/Customer.php
@@ -34,7 +34,10 @@ class Customer extends Member {
 	 * @see Member::canDelete()
 	 */
 	public function canDelete($member = null) {
-
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		$orders = $this->Orders();
 		if ($orders && $orders->exists()) {
 			return false;

--- a/code/order/Order.php
+++ b/code/order/Order.php
@@ -194,6 +194,10 @@ class Order extends DataObject implements PermissionProvider {
 	}
 
 	public function canView($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 
 		if ($member == null && !$member = Member::currentUser()) return false;
 
@@ -210,6 +214,11 @@ class Order extends DataObject implements PermissionProvider {
 	 * @return Boolean False always
 	 */
 	public function canEdit($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+
 		$administratorPerm = Permission::check('ADMIN') && Permission::check('EDIT_ORDER', 'any', $member);
 		
 		return $administratorPerm;
@@ -222,6 +231,11 @@ class Order extends DataObject implements PermissionProvider {
 	 * @return Boolean False always
 	 */
 	public function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+
 		return false;
 	}
 	
@@ -232,6 +246,11 @@ class Order extends DataObject implements PermissionProvider {
 	 * @return Boolean False always
 	 */
 	public function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
+
 		return Permission::check('ADMIN');
 	}
 

--- a/code/product/Attribute.php
+++ b/code/product/Attribute.php
@@ -74,18 +74,34 @@ class Attribute extends DataObject implements PermissionProvider {
 	}
 
 	public function canEdit($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_ATTRIBUTES');
 	}
 
 	public function canView($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return true;
 	}
 
 	public function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_ATTRIBUTES');
 	}
 
 	public function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_ATTRIBUTES');
 	}
 

--- a/code/product/Option.php
+++ b/code/product/Option.php
@@ -54,18 +54,34 @@ class Option extends DataObject implements PermissionProvider {
 	}
 
 	public function canEdit($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_OPTIONS');
 	}
 
 	public function canView($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return true;
 	}
 
 	public function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_OPTIONS');
 	}
 
 	public function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_OPTIONS');
 	}
 

--- a/code/product/Variation.php
+++ b/code/product/Variation.php
@@ -99,18 +99,34 @@ class Variation extends DataObject implements PermissionProvider {
 	}
 
 	public function canEdit($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_VARIATIONS');
 	}
 
 	public function canView($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return true;
 	}
 
 	public function canDelete($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_VARIATIONS');
 	}
 
 	public function canCreate($member = null) {
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
+		}
 		return Permission::check('EDIT_VARIATIONS');
 	}
 	


### PR DESCRIPTION
This allows extensions to change the default behaviour of the module.
Eg. I am using this fork to implement a manual ordering system for accepting phone orders or mailed in cheque orders - without this change you can't create an Order via GridField or any other way that checks canCreate permissions correctly.
